### PR TITLE
Add Android intent actions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,6 +28,18 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="org.traccar.client.START"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="org.traccar.client.STOP"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="org.traccar.client.SOS"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/android/app/src/main/kotlin/org/traccar/client/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/traccar/client/MainActivity.kt
@@ -1,5 +1,27 @@
 package org.traccar.client
 
+import android.content.Intent
+import android.os.Bundle
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private val CHANNEL = "org.traccar.client/intent"
+
+    private fun handleIntent(action: String?) {
+        if (action == null) return
+        val engine = flutterEngine ?: return
+        MethodChannel(engine.dartExecutor.binaryMessenger, CHANNEL)
+            .invokeMethod("action", action)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        handleIntent(intent?.action)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleIntent(intent.action)
+    }
+}


### PR DESCRIPTION
## Summary
- handle custom intents in `MainActivity` and forward them to Flutter
- support start/stop/sos intents in Android manifest
- process intent actions via method channel in `QuickActionsInitializer`

## Testing
- `cd android && ./gradlew test` *(fails: `bash: ./gradlew: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6848e76817b0832885c9dd2c70cb0aee