### PR TITLE
Implement exit after quick action

### DIFF
--- a/lib/quick_actions.dart
+++ b/lib/quick_actions.dart
@@ -1,6 +1,7 @@
 import 'dart:developer' as developer;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:quick_actions/quick_actions.dart';
 import 'package:flutter_background_geolocation/flutter_background_geolocation.dart' as bg;
 
@@ -33,6 +34,9 @@ class _QuickActionsInitializerState extends State<QuickActionsInitializer> {
           } catch (error) {
             developer.log('Failed to send alert', error: error);
           }
+      }
+      if (mounted) {
+        SystemNavigator.pop();
       }
     });
   }


### PR DESCRIPTION
## Summary
- allow the app to close automatically after a quick action is handled

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2c64f75883288decb57a28241acb