### PR TITLE
Fix dialog overflow issue

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -52,6 +52,7 @@ class _MainScreenState extends State<MainScreen> {
           showDialog(
             context: context,
             builder: (_) => AlertDialog(
+              scrollable: true,
               content: Text(AppLocalizations.of(context)!.optimizationMessage),
               actions: [
                 TextButton(

--- a/lib/password_service.dart
+++ b/lib/password_service.dart
@@ -14,6 +14,7 @@ class PasswordService {
       result = await showDialog<bool>(
         context: context,
         builder: (context) => AlertDialog(
+          scrollable: true,
           content: TextField(
             controller: controller,
             autofocus: true,

--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -41,6 +41,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final result = await showDialog<String>(
       context: context,
       builder: (context) => AlertDialog(
+        scrollable: true,
         title: Text(title),
         content: TextField(
           controller: controller,
@@ -89,6 +90,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final result = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
+        scrollable: true,
         content: TextField(
           controller: controller,
           decoration: InputDecoration(labelText: AppLocalizations.of(context)!.passwordLabel),


### PR DESCRIPTION
## Summary
- prevent RenderFlex overflow in alert dialogs by making them scrollable

## Testing
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6870813d802c8328b4336c4879d25166