### PR TITLE
Fix text field dismissal

### DIFF
--- a/lib/password_service.dart
+++ b/lib/password_service.dart
@@ -22,13 +22,17 @@ class PasswordService {
           ),
           actions: [
             TextButton(
-              onPressed: () => Navigator.pop(context, false),
+              onPressed: () {
+                FocusScope.of(context).unfocus();
+                Navigator.pop(context, false);
+              },
               child: Text(AppLocalizations.of(context)!.cancelButton),
             ),
             TextButton(
               onPressed: () async {
                 final password = await _secureStorage.read(key: _passwordKey);
                 if (context.mounted) {
+                  FocusScope.of(context).unfocus();
                   Navigator.pop(context, password == controller.text);
                 }
               },
@@ -38,6 +42,7 @@ class PasswordService {
         ),
       );
     }
+    controller.dispose();
     if (result != true && context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(AppLocalizations.of(context)!.passwordError)),

--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -49,16 +49,24 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () {
+              FocusScope.of(context).unfocus();
+              Navigator.pop(context);
+            },
             child: Text(AppLocalizations.of(context)!.cancelButton),
           ),
           TextButton(
-            onPressed: () => Navigator.pop(context, controller.text),
+            onPressed: () {
+              FocusScope.of(context).unfocus();
+              Navigator.pop(context, controller.text);
+            },
             child: Text(AppLocalizations.of(context)!.saveButton),
           ),
         ],
       ),
     );
+
+    controller.dispose();
 
     if (result != null && result.isNotEmpty) {
       if (key == Preferences.url) {
@@ -96,11 +104,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context, false),
+            onPressed: () {
+              FocusScope.of(context).unfocus();
+              Navigator.pop(context, false);
+            },
             child: Text(AppLocalizations.of(context)!.cancelButton),
           ),
           TextButton(
-            onPressed: () => Navigator.pop(context, true),
+            onPressed: () {
+              FocusScope.of(context).unfocus();
+              Navigator.pop(context, true);
+            },
             child: Text(AppLocalizations.of(context)!.saveButton),
           ),
         ],
@@ -109,6 +123,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (result == true) {
       await PasswordService.setPassword(controller.text);
     }
+    controller.dispose();
   }
 
   Widget _buildListTile(String title, String key, bool isInt) {


### PR DESCRIPTION
## Summary
- ensure text fields are unfocused before closing dialogs
- dispose dialog controllers

## Testing
- `dart format -o none lib/settings_screen.dart lib/password_service.dart` *(fails: command not found)*
- `flutter format lib/settings_screen.dart lib/password_service.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687081a93bf48328a3a36377875c3e60