### PR TITLE
Fix race condition causing excessive location uploads (60k-140k/day)

### DIFF
--- a/lib/geolocation_service.dart
+++ b/lib/geolocation_service.dart
@@ -52,7 +52,11 @@ class GeolocationService {
         developer.log('Failed to delete location', error: error);
       }
     } else {
-      LocationCache.set(location);
+      try {
+        await LocationCache.set(location);
+      } catch (error) {
+        developer.log('Failed to cache location', error: error);
+      }
       try {
         await bg.BackgroundGeolocation.sync();
       } catch (error) {
@@ -66,7 +70,10 @@ class GeolocationService {
     if (location.extras?.isNotEmpty == true) return false;
 
     final lastLocation = LocationCache.get();
-    if (lastLocation == null) return false;
+    if (lastLocation == null) {
+      developer.log('Location cache is null, skipping filtering');
+      return false;
+    }
 
     final isHighestAccuracy = Preferences.instance.getString(Preferences.accuracy) == 'highest';
     final duration = DateTime.parse(location.timestamp).difference(DateTime.parse(lastLocation.timestamp)).inSeconds;

--- a/lib/location_cache.dart
+++ b/lib/location_cache.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter_background_geolocation/flutter_background_geolocation.dart' as bg;
 import 'package:traccar_client/preferences.dart';
 
@@ -19,17 +21,21 @@ class LocationCache {
 
   static Location? get() {
     if (_last == null) {
-      final timestamp = Preferences.instance.getString(Preferences.lastTimestamp);
-      final latitude = Preferences.instance.getDouble(Preferences.lastLatitude);
-      final longitude = Preferences.instance.getDouble(Preferences.lastLongitude);
-      final heading = Preferences.instance.getDouble(Preferences.lastHeading);
-      if (timestamp != null && latitude != null && longitude != null && heading != null) {
-        _last = Location(
-          timestamp: timestamp,
-          latitude: latitude,
-          longitude: longitude,
-          heading: heading,
-        );
+      try {
+        final timestamp = Preferences.instance.getString(Preferences.lastTimestamp);
+        final latitude = Preferences.instance.getDouble(Preferences.lastLatitude);
+        final longitude = Preferences.instance.getDouble(Preferences.lastLongitude);
+        final heading = Preferences.instance.getDouble(Preferences.lastHeading);
+        if (timestamp != null && latitude != null && longitude != null && heading != null) {
+          _last = Location(
+            timestamp: timestamp,
+            latitude: latitude,
+            longitude: longitude,
+            heading: heading,
+          );
+        }
+      } catch (error) {
+        developer.log('Failed to read location cache', error: error);
       }
     }
     return _last;
@@ -42,10 +48,10 @@ class LocationCache {
       longitude: location.coords.longitude,
       heading: location.coords.heading,
     );
-    Preferences.instance.setString(Preferences.lastTimestamp, last.timestamp);
-    Preferences.instance.setDouble(Preferences.lastLatitude, last.latitude);
-    Preferences.instance.setDouble(Preferences.lastLongitude, last.longitude);
-    Preferences.instance.setDouble(Preferences.lastHeading, last.heading);
+    await Preferences.instance.setString(Preferences.lastTimestamp, last.timestamp);
+    await Preferences.instance.setDouble(Preferences.lastLatitude, last.latitude);
+    await Preferences.instance.setDouble(Preferences.lastLongitude, last.longitude);
+    await Preferences.instance.setDouble(Preferences.lastHeading, last.heading);
     _last = last;
   }
 }


### PR DESCRIPTION
Detail is here: https://github.com/traccar/traccar-client/issues/95#issuecomment-3410005933

Problem:
- LocationCache.set() did not await SharedPreferences writes
- Cache could become null/corrupted due to race conditions
- When cache is null, all locations bypass filtering and sent to server
- Result: 60,000-140,000 points/day instead of normal 1,000-4,000

Solution:
- Add await for all SharedPreferences operations in LocationCache
- Add await for LocationCache.set() call in GeolocationService
- Add error handling with try-catch blocks
- Add diagnostic logging when cache is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)