### PR TITLE
Auto-expire release artifacts after one day

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
           name: android-apk
           path: build/app/outputs/flutter-apk/app-release.apk
           if-no-files-found: error
+          retention-days: 1
 
   smoke-test-android:
     needs: build-android
@@ -197,6 +198,7 @@ jobs:
           name: ios-ipa
           path: ${{ runner.temp }}/ipa/*.ipa
           if-no-files-found: error
+          retention-days: 1
 
   publish-ios:
     needs: build-ios


### PR DESCRIPTION
## Summary
- Add \`retention-days: 1\` to the Android APK and iOS IPA uploads in the Release workflow so they auto-expire ~24h after a run instead of consuming Actions artifact storage for the default 90 days.
- Smoke-test screenshot keeps the default 90-day retention (tiny, useful for diagnosing past failures).

## Test plan
- [ ] Next tagged release run completes normally and the workflow shows artifacts with 1-day expiration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)