### PR TITLE
Install flutterfire CLI in iOS build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,9 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Install flutterfire CLI
+        run: dart pub global activate flutterfire_cli
+
       - name: Import signing certificate into temp keychain
         env:
           CERT_P12_BASE64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}


### PR DESCRIPTION
## Summary
- The iOS build was failing at the \"Archive and export IPA\" step with \`flutterfire: command not found\`.
- Root cause: the Xcode project has a Run Script build phase invoking \`flutterfire upload-crashlytics-symbols\` (auto-added by FlutterFire CLI when Crashlytics was configured locally). The macOS runner doesn't ship with the CLI.
- Fix: activate \`flutterfire_cli\` via \`dart pub global\` before the xcodebuild step. The build script already adds \`\$HOME/.pub-cache/bin\` to PATH so the binary is picked up.

## Test plan
- [ ] After merging and re-tagging, build-ios completes through the Archive step.
- [ ] dSYMs visible in Firebase Crashlytics for the new build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)