### PR TITLE
Allow upsidedown on ios

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -91,6 +91,7 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>


### PR DESCRIPTION
The ios one was easy to fix for someone how don't know mobile programming, the android part i don't know how to do. And on Android, you can download apps that force rotation (even without root access).

Fix: #190 
